### PR TITLE
解决CustomWebview当前demo无法使用的问题

### DIFF
--- a/example/src/main/java/com/github/lzyzsd/jsbridge/example/CustomWebView.java
+++ b/example/src/main/java/com/github/lzyzsd/jsbridge/example/CustomWebView.java
@@ -12,6 +12,9 @@ import com.github.lzyzsd.jsbridge.BridgeHelper;
 import com.github.lzyzsd.jsbridge.IWebView;
 import com.github.lzyzsd.jsbridge.OnBridgeCallback;
 import com.github.lzyzsd.jsbridge.WebViewJavascriptBridge;
+import com.google.gson.Gson;
+
+import java.util.Map;
 
 /**
  * 采用BridgeHelper集成JsBridge功能示例.定制WebView,可只添加实际需要的JsBridge接口.
@@ -23,6 +26,8 @@ import com.github.lzyzsd.jsbridge.WebViewJavascriptBridge;
 public class CustomWebView extends WebView implements WebViewJavascriptBridge, IWebView {
 
     private BridgeHelper bridgeHelper;
+
+    private Gson mGson;
 
     public CustomWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -114,5 +119,23 @@ public class CustomWebView extends WebView implements WebViewJavascriptBridge, I
     @Override
     public void sendToWeb(String function, Object... values) {
         bridgeHelper.sendToWeb(function, values);
+    }
+
+    @Override
+    public void responseFromWeb(String data, String callbackId) {
+        bridgeHelper.responseFromWeb(data,callbackId);
+    }
+
+    public void setGson(Gson gson){
+        this.mGson = gson;
+    }
+
+    public Map<String, OnBridgeCallback> getCallbacks() {
+        return bridgeHelper.getCallbacks();
+    }
+
+    @Override
+    public WebView getWebView() {
+        return this;
     }
 }

--- a/example/src/main/java/com/github/lzyzsd/jsbridge/example/MainJavascriptInterface.java
+++ b/example/src/main/java/com/github/lzyzsd/jsbridge/example/MainJavascriptInterface.java
@@ -5,6 +5,7 @@ import android.webkit.JavascriptInterface;
 
 import com.github.lzyzsd.jsbridge.BridgeWebView;
 import com.github.lzyzsd.jsbridge.OnBridgeCallback;
+import com.github.lzyzsd.jsbridge.WebViewJavascriptBridge;
 
 import java.util.Map;
 
@@ -15,9 +16,10 @@ import java.util.Map;
  */
 public class MainJavascriptInterface extends BridgeWebView.BaseJavascriptInterface {
 
-    private BridgeWebView mWebView;
+    //WebJSbridge
+    private WebViewJavascriptBridge mWebView;
 
-    public MainJavascriptInterface(Map<String, OnBridgeCallback> callbacks, BridgeWebView webView) {
+    public MainJavascriptInterface(Map<String, OnBridgeCallback> callbacks, WebViewJavascriptBridge webView) {
         super(callbacks);
         mWebView = webView;
     }
@@ -35,6 +37,6 @@ public class MainJavascriptInterface extends BridgeWebView.BaseJavascriptInterfa
     @JavascriptInterface
     public void submitFromWeb(String data, String callbackId) {
         Log.d("MainJavascriptInterface", data + ", callbackId: " + callbackId + " " + Thread.currentThread().getName());
-        mWebView.sendResponse("submitFromWeb response", callbackId);
+        mWebView.responseFromWeb("submitFromWeb response", callbackId);
     }
 }

--- a/library/src/main/assets/WebViewJavascriptBridge.js
+++ b/library/src/main/assets/WebViewJavascriptBridge.js
@@ -181,6 +181,7 @@
     WebViewJavascriptBridge.registerHandler = registerHandler;
     WebViewJavascriptBridge.callHandler = callHandler;
     WebViewJavascriptBridge._handleMessageFromNative = _handleMessageFromNative;
+    WebViewJavascriptBridge._fetchQueue = _fetchQueue;
 
     var readyEvent = document.createEvent('Events');
     var jobs = window.WVJBCallbacks || [];

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/BridgeWebView.java
@@ -140,6 +140,11 @@ public class BridgeWebView extends WebView implements WebViewJavascriptBridge, B
         }
     }
 
+    @Override
+    public void responseFromWeb(String data, String callbackId) {
+        sendResponse(data,callbackId);
+    }
+
     /**
      * 保存message到消息队列
      *
@@ -222,7 +227,6 @@ public class BridgeWebView extends WebView implements WebViewJavascriptBridge, B
                     }
                 });
             }
-
         }
     }
 

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/IWebView.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/IWebView.java
@@ -1,6 +1,7 @@
 package com.github.lzyzsd.jsbridge;
 
 import android.content.Context;
+import android.webkit.WebView;
 
 /**
  * WebView功能接口.
@@ -13,4 +14,9 @@ public interface IWebView {
     Context getContext();
 
     void loadUrl(String url);
+
+    /**
+     * 获取当前Webview
+     */
+    WebView getWebView();
 }

--- a/library/src/main/java/com/github/lzyzsd/jsbridge/WebViewJavascriptBridge.java
+++ b/library/src/main/java/com/github/lzyzsd/jsbridge/WebViewJavascriptBridge.java
@@ -9,4 +9,11 @@ public interface WebViewJavascriptBridge {
 
 	void sendToWeb(String function, Object... values);
 
+	/**
+	 * 处理从js返回的数据
+	 * @param data 数据
+	 * @param callbackId jsCallbackId
+	 */
+	void responseFromWeb(String data,String callbackId);
+
 }


### PR DESCRIPTION
解决CustomWebview在demo上无法使用的一些问题
* 修复java调用js，js报错的问题
* 解决当前bridge.js无法调用到java注册的函数方法以及回调方法的问题
* BridgeHelper同步BridgeWebview中jsbridge的方式
* 将BridgeWebview替换成CustomWebview，可实现demo的全部功能