### PR TITLE
Delete library/src/main/res directory

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">library</string>
-</resources>


### PR DESCRIPTION
作为lib库，不应该声明app_name，可能会与主app中资源重名